### PR TITLE
Add cat hunger disable toggle

### DIFF
--- a/commands/admin/toggle.js
+++ b/commands/admin/toggle.js
@@ -28,15 +28,15 @@ module.exports = {
                 await guildSettings.setSkin(guildId, skin);
                 stringToSend += `Skin set to ${skin}\n`;
             }
-            if (shouting) {
+            if (shouting !== null) {
                 await guildSettings.toggleShouting(guildId, shouting);
                 stringToSend += `Shouting set to ${shouting}\n`;
             }
-            if (hunger) {
+            if (hunger !== null) {
                 await guildSettings.toggleHunger(guildId, hunger);
                 stringToSend += `Hunger set to ${hunger}\n`;
             }
-            if (!skin && !shouting && !hunger) {
+            if (!skin && shouting === null && hunger === null) {
                 stringToSend += `Skin: ${thisGuildSettings.skin}\nShouting: ${thisGuildSettings.shouting}\nHunger: ${thisGuildSettings.hunger}`;
             }
             await interaction.reply(stringToSend);
@@ -46,8 +46,8 @@ module.exports = {
             const thisGuildSettings = await guildSettings.getSettings(guildId);
             const skin = interaction.content.match(/(?<=skin )\w+/mi);
             // shouting is a boolean so we can just check if it's in the message
-            const shouting = interaction.content.contains('shouting');
-            const hunger = interaction.content.contains('hunger');
+            const shouting = interaction.content.includes('shouting');
+            const hunger = interaction.content.includes('hunger');
             if (skin) {
                 await guildSettings.setSkin(guildId, skin[0]);
                 await interaction.reply(`Skin set to ${skin[0]}`);

--- a/commands/admin/toggle.js
+++ b/commands/admin/toggle.js
@@ -10,7 +10,10 @@ module.exports = {
                 .addChoices({ name: 'Default', value: 'default' }, { name: 'Fox', value: 'foxxo' }))
         .addBooleanOption(option =>
             option.setName('shouting')
-                .setDescription('Whether or not to enable shouting')),
+                .setDescription('Whether or not to enable shouting'))
+        .addBooleanOption(option =>
+            option.setName('hunger')
+                .setDescription('Whether or not to enable hunger system')),
 	async execute(interaction, guildSettings) {
         // check if this is an interaction, or a message command
         // as gross as this is, it's this or create two separate commands for the same thing
@@ -18,6 +21,7 @@ module.exports = {
             const guildId = interaction.guildId;
             const skin = interaction.options.getString('skin');
             const shouting = interaction.options.getBoolean('shouting');
+            const hunger = interaction.options.getBoolean('hunger');
             const thisGuildSettings = await guildSettings.getSettings(guildId);
             let stringToSend = '';
             if (skin) {
@@ -28,8 +32,12 @@ module.exports = {
                 await guildSettings.toggleShouting(guildId, shouting);
                 stringToSend += `Shouting set to ${shouting}\n`;
             }
-            if (!skin && !shouting) {
-                stringToSend += `Skin: ${thisGuildSettings.skin}\nShouting: ${thisGuildSettings.shouting}`;
+            if (hunger) {
+                await guildSettings.toggleHunger(guildId, hunger);
+                stringToSend += `Hunger set to ${hunger}\n`;
+            }
+            if (!skin && !shouting && !hunger) {
+                stringToSend += `Skin: ${thisGuildSettings.skin}\nShouting: ${thisGuildSettings.shouting}\nHunger: ${thisGuildSettings.hunger}`;
             }
             await interaction.reply(stringToSend);
         }
@@ -39,6 +47,7 @@ module.exports = {
             const skin = interaction.content.match(/(?<=skin )\w+/mi);
             // shouting is a boolean so we can just check if it's in the message
             const shouting = interaction.content.contains('shouting');
+            const hunger = interaction.content.contains('hunger');
             if (skin) {
                 await guildSettings.setSkin(guildId, skin[0]);
                 await interaction.reply(`Skin set to ${skin[0]}`);
@@ -47,8 +56,12 @@ module.exports = {
                 const guild = await guildSettings.toggleShouting(guildId);
                 await interaction.reply(`Shouting set to ${guild.shouting}`);
             }
-            if (!skin && !shouting) {
-                await interaction.reply(`Skin: ${thisGuildSettings.skin}\nShouting: ${thisGuildSettings.shouting}`);
+            if (hunger) {
+                const guild = await guildSettings.toggleHunger(guildId);
+                await interaction.reply(`Hunger set to ${guild.hunger}`);
+            }
+            if (!skin && !shouting && !hunger) {
+                await interaction.reply(`Skin: ${thisGuildSettings.skin}\nShouting: ${thisGuildSettings.shouting}\nHunger: ${thisGuildSettings.hunger}`);
             }
         }
 	},

--- a/models/guild.js
+++ b/models/guild.js
@@ -40,6 +40,11 @@ const guildSchema = new mongoose.Schema({
         required: true,
         default: true,
     },
+    enableHunger: {
+        type: Boolean,
+        required: true,
+        default: true,
+    },
     skin: {
         type: String,
         required: true,

--- a/updateSchemas.js
+++ b/updateSchemas.js
@@ -12,6 +12,7 @@ async function updateSchemas() {
         const settings = await guildSettings.getSettings(guild.snowflake);
         guild.enableSim = settings.sim;
         guild.enableShouting = settings.shouting;
+        guild.enableHunger = settings.hunger;
         guild.skin = settings.skin;
         await guild.save();
     }

--- a/utils/cat.js
+++ b/utils/cat.js
@@ -14,7 +14,8 @@ class Cat {
         // mood is controlled by the guild model, updates every time that a search is called for the guild
         this.mood = guildSearch.mood;
         this.guild = guildSearch;
-        this.hunger = guildSearch.hunger;
+        // if hunger is disabled, always return 10 (max hunger)
+        this.hunger = guildSearch.enableHunger ? guildSearch.hunger : 10;
         this.user = userSearch;
         this.skin = skin;
         this.strings = stringBuilder.buildStrings(skin);
@@ -95,7 +96,7 @@ class Cat {
                 return foundString;
             }
             // grace period for the user to interact with the cat before it nags about being hungry
-            else if (this.hunger <= 4 && this.guild.interactionCount == 0) {
+            else if (this.guild.enableHunger && this.hunger <= 4 && this.guild.interactionCount == 0) {
                 foundString = this.strings.hunger.yes[Math.floor(Math.random() * this.strings.hunger.yes.length)];
                 return foundString;
             }
@@ -155,7 +156,7 @@ class Cat {
                 console.log('defaulted, action was ' + action);
             }
             if (action === 'hunger') {
-                if (this.hunger <= 4) {
+                if (this.guild.enableHunger && this.hunger <= 4) {
                     foundString = foundAction.yes[Math.floor(Math.random() * foundAction.yes.length)];
                 }
                 else {
@@ -170,6 +171,11 @@ class Cat {
 
     }
     async feed() {
+        // if hunger is disabled, always act as if the cat is not hungry
+        if (!this.guild.enableHunger) {
+            return this.strings.hunger.no[Math.floor(Math.random() * this.strings.hunger.no.length)];
+        }
+        
         // if hunger is below 4, then meow is hungy
         const hungy = this.hunger <= 4;
 

--- a/utils/guild.js
+++ b/utils/guild.js
@@ -32,6 +32,7 @@ class GuildSettings {
             }
             this.guilds.set(guildId, {
                 shouting: search.enableShouting,
+                hunger: search.enableHunger,
                 skin: search.skin,
             });
             return this.guilds.get(guildId);
@@ -55,6 +56,7 @@ class GuildSettings {
         await search.save();
         this.guilds.set(guildId, {
             shouting: search.enableShouting,
+            hunger: search.enableHunger,
             skin: search.skin,
         });
         return this.guilds.get(guildId);
@@ -80,6 +82,33 @@ class GuildSettings {
         await search.save();
         this.guilds.set(guildId, {
             shouting: search.enableShouting,
+            hunger: search.enableHunger,
+            skin: search.skin,
+        });
+        return this.guilds.get(guildId);
+    }
+    /**
+     * Toggles the hunger system on a server
+     * @param {Snowflake} guildId The guild ID
+     * @returns {Object} The settings of the guild
+     */
+    async toggleHunger(guildId, force) {
+        const search = await Guild.checkGuild(guildId);
+        if (!force) {
+            if (search.enableHunger === true) {
+                search.enableHunger = false;
+            }
+            else {
+                search.enableHunger = true;
+            }
+        }
+        else {
+            search.enableHunger = force;
+        }
+        await search.save();
+        this.guilds.set(guildId, {
+            shouting: search.enableShouting,
+            hunger: search.enableHunger,
             skin: search.skin,
         });
         return this.guilds.get(guildId);


### PR DESCRIPTION
Add a toggle to disable the cat's hunger system and fix boolean logic for toggle commands.

The previous implementation of boolean options in the `/toggle` command used `if (optionName)` which would incorrectly evaluate to `false` if the user explicitly set the option to `false`. This PR fixes this by checking `if (optionName !== null)` to ensure the option was provided, regardless of its boolean value. Additionally, a typo `contains()` was corrected to `includes()` for message commands.